### PR TITLE
Fix crash caused by accessing CryptoRepo too early

### DIFF
--- a/hiOS/CoinAPIHelper.swift
+++ b/hiOS/CoinAPIHelper.swift
@@ -134,6 +134,7 @@ class CryptoRepo {
      
     */
     func getElemById(id : String) -> Cryptocurrency {
+        // TODO: Consider checking before unwrapping Optionals
         return cryptoList[id]!
     }
 }

--- a/hiOS/ViewController.swift
+++ b/hiOS/ViewController.swift
@@ -75,7 +75,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         switch indexPath.section {
             case 0:
                 let list = favorites.getList()
-                if (list.count > 0) {
+                if (list.count > 0 && cryptoRepo.getCount() > 0) {
                     guard let id = list[indexPath.row].name else {
                         return cell
                     }


### PR DESCRIPTION
We need to ensure that CryptoRepo is actually populated before doing anything.

This might just be a temporary hotfix. Maybe there's a better way to do this.